### PR TITLE
Return empty string when stripping undefined

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,6 @@
 module.exports = strip;
 
 function strip(html){
+  html = html || '';
   return html.replace(/<\/?([a-z][a-z0-9]*)\b[^>]*>?/gi, '').trim();
 }

--- a/test.js
+++ b/test.js
@@ -20,3 +20,10 @@ test('html markup inside comments do not fail', function(t){
   t.equal(strip(html), 'this has markup in a <!--comment markup--> in it');
   t.end();
 });
+
+test('undefined html arg returns empty string', function(t){
+  var html;
+  t.equal(strip(html), '');
+  t.end();
+});
+


### PR DESCRIPTION
It's handy to be able to expect a string from strip() even if you pass it an undefined argument.
